### PR TITLE
Improve styling with flexbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ One of the props (onAccept) is a function, this function will be called after th
 | buttonText    | String or React component        | I understand  | Text to appear on the button                                                                          |
 | cookieName    | string                           | CookieConsent | Name of the cookie used to track whether the user has agreed.                                         |
 | onAccept      | function                         | () => {}      | Function to be called after the accept button has been clicked.                                       |
-| style      | Object                           | [style](style) | React styling object for the bar.                                                              |
+| style      | Object                           | [style](style) | React styling object for the bar.                                                                       |
 | buttonStyle   | Object                           | [buttonStyle](buttonStyle) | React styling object for the button.                                                     |
-| contentStyle  | Object                           | [contentStyle](contentStyle) | React styling object for the button.                                                   |
+| contentStyle  | Object                           | {}            | React styling object for the content.                                                                 |
 
 ## Styling it
 
@@ -148,4 +148,3 @@ import CookieConsent, { Cookies } from "react-cookie-consent";
 
 [style]: https://github.com/karland/react-cookie-consent/blob/master/src/index.js#L17-L28
 [buttonStyle]: https://github.com/karland/react-cookie-consent/blob/master/src/index.js#L29
-[contentStyle]: https://github.com/karland/react-cookie-consent/blob/master/src/index.js#L30-L39

--- a/README.md
+++ b/README.md
@@ -147,5 +147,5 @@ import CookieConsent, { Cookies } from "react-cookie-consent";
 </CookieConsent>
 ```
 
-[style]: https://github.com/karland/react-cookie-consent/blob/master/src/index.js#L17-L28
-[buttonStyle]: https://github.com/karland/react-cookie-consent/blob/master/src/index.js#L29-L38
+[style]: https://github.com/Mastermindzh/react-cookie-consent/blob/master/src/index.js#L17-L28
+[buttonStyle]: https://github.com/Mastermindzh/react-cookie-consent/blob/master/src/index.js#L29-L38

--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ One of the props (onAccept) is a function, this function will be called after th
 | buttonText    | String or React component        | I understand  | Text to appear on the button                                                                          |
 | cookieName    | string                           | CookieConsent | Name of the cookie used to track whether the user has agreed.                                         |
 | onAccept      | function                         | () => {}      | Function to be called after the accept button has been clicked.                                       |
-| style      | Object                           | [style](style) | React styling object for the bar.                                                                       |
-| buttonStyle   | Object                           | [buttonStyle](buttonStyle) | React styling object for the button.                                                     |
+| style         | Object                           | [look at source][style] | React styling object for the bar.                                                           |
+| buttonStyle   | Object                           | [look at source][buttonStyle] | React styling object for the button.                                                  |
 | contentStyle  | Object                           | {}            | React styling object for the content.                                                                 |
 
 ## Styling it

--- a/README.md
+++ b/README.md
@@ -77,15 +77,14 @@ One of the props (onAccept) is a function, this function will be called after th
 | Prop          |               Type               | Default value | Description                                                                                           |
 |---------------|:--------------------------------:|---------------|-------------------------------------------------------------------------------------------------------|
 | location      | String, either "top" or "bottom" | bottom        | Syntactic sugar to easily enable you to place the bar at the top or the bottom of the browser window. |
-| children      |     String or React component    |               | Content to appear inside the bar                                                                      |
-| disableStyles |              boolean             | false         | If enabled the component will have no default style. (you can still supply style through props)       |
-| buttonText    |              String or React component              | I understand  | Text to appear on the button                                                                          |
-| cookieName    |              string              | CookieConsent | Name of the cookie used to track whether the user has agreed.                                         |
-| onAccept      |             function             | () => {}      | Function to be called after the accept button has been clicked.                                       |
-| style         |              Object              |  ![barstyle](https://github.com/Mastermindzh/react-cookie-consent/blob/master/images/barStyle.png?raw=true)             | React styling object for the bar.                                                                     |
-| buttonStyle   |              Object              |   ![buttonStyle](https://github.com/Mastermindzh/react-cookie-consent/blob/master/images/buttonStyle.png?raw=true)              | React styling object for the button.                                                                  |
-
-
+| children      | String or React component        |               | Content to appear inside the bar                                                                      |
+| disableStyles | boolean                          | false         | If enabled the component will have no default style. (you can still supply style through props)       |
+| buttonText    | String or React component        | I understand  | Text to appear on the button                                                                          |
+| cookieName    | string                           | CookieConsent | Name of the cookie used to track whether the user has agreed.                                         |
+| onAccept      | function                         | () => {}      | Function to be called after the accept button has been clicked.                                       |
+| style      | Object                           | [style](style) | React styling object for the bar.                                                              |
+| buttonStyle   | Object                           | [buttonStyle](buttonStyle) | React styling object for the button.                                                     |
+| contentStyle  | Object                           | [contentStyle](contentStyle) | React styling object for the button.                                                   |
 
 ## Styling it
 
@@ -146,3 +145,7 @@ import CookieConsent, { Cookies } from "react-cookie-consent";
 >
 </CookieConsent>
 ```
+
+[style]:
+[buttonStyle]:
+[contentStyle]:

--- a/README.md
+++ b/README.md
@@ -88,8 +88,9 @@ One of the props (onAccept) is a function, this function will be called after th
 
 ## Styling it
 
-You can provide styling for both the bar and the button.
-You can do this using the `style` and `buttonStyle` prop, both of these will append / replace the default style of the component.
+You can provide styling for the bar, for the button and the content. Note that the bar is a parent has a `display: flex` property as default and is parent to its children content and button. 
+
+You can style each component with using the `style`, `buttonStyle` and `contentStyle` prop. These will append / replace the default styles of the components.
 
 You can use `disableStyles={true}` to disable any built-in styling.
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ One of the props (onAccept) is a function, this function will be called after th
 
 ## Styling it
 
-You can provide styling for the bar, for the button and the content. Note that the bar is a parent has a `display: flex` property as default and is parent to its children content and button. 
+You can provide styling for the bar, for the button and the content. Note that the bar has a `display: flex` property as default and is parent to its children content and button. 
 
 You can style each component with using the `style`, `buttonStyle` and `contentStyle` prop. These will append / replace the default styles of the components.
 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,6 @@ import CookieConsent, { Cookies } from "react-cookie-consent";
 </CookieConsent>
 ```
 
-[style]:
-[buttonStyle]:
-[contentStyle]:
+[style]: https://github.com/karland/react-cookie-consent/blob/master/src/index.js#L17-L28
+[buttonStyle]: https://github.com/karland/react-cookie-consent/blob/master/src/index.js#L29
+[contentStyle]: https://github.com/karland/react-cookie-consent/blob/master/src/index.js#L30-L39

--- a/README.md
+++ b/README.md
@@ -147,4 +147,4 @@ import CookieConsent, { Cookies } from "react-cookie-consent";
 ```
 
 [style]: https://github.com/karland/react-cookie-consent/blob/master/src/index.js#L17-L28
-[buttonStyle]: https://github.com/karland/react-cookie-consent/blob/master/src/index.js#L29
+[buttonStyle]: https://github.com/karland/react-cookie-consent/blob/master/src/index.js#L29-L38

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,6 @@ class CookieConsent extends Component {
         width: "100%",
         zIndex: "999"
       },
-      contentStyle: {},
       buttonStyle: {
         background: "#ffd42d",
         border: "0",
@@ -36,7 +35,8 @@ class CookieConsent extends Component {
         flex: "0 0 auto",
         marginLeft: "15px",
         padding: "5px 10px"
-      }
+      },
+      contentStyle: {}
     };
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -76,13 +76,13 @@ class CookieConsent extends Component {
 
     let myStyle = {};
     let myButtonStyle = {};
-    let myTextStyle = {};
+    let myContentStyle = {};
 
     if (disableStyles) {
       // if styles are disabled use the provided styles (or non)
       myStyle = Object.assign({}, style);
       myButtonStyle = Object.assign({}, buttonStyle);
-      myTextStyle = Object.assign({}, contentStyle);
+      myContentStyle = Object.assign({}, contentStyle);
     } else {
       // if styles aren't disabled merge them with the styles that are provided (or use default styles)
       myStyle = Object.assign({}, { ...this.state.style, ...style });
@@ -90,7 +90,7 @@ class CookieConsent extends Component {
         {},
         { ...this.state.buttonStyle, ...buttonStyle }
       );
-      myTextStyle = Object.assign(
+      myContentStyle = Object.assign(
         {},
         { ...this.state.contentStyle, ...contentStyle }
       );
@@ -109,7 +109,7 @@ class CookieConsent extends Component {
 
     return (
       <div className="cookieConsent" style={myStyle}>
-        <div style={myTextStyle}>{this.props.children}</div>
+        <div style={myContentStyle}>{this.props.children}</div>
         <button
           style={myButtonStyle}
           onClick={() => {

--- a/src/index.js
+++ b/src/index.js
@@ -15,33 +15,35 @@ class CookieConsent extends Component {
     this.state = {
       visible: true,
       style: {
-        position: "fixed",
-        width: "100%",
-        padding: "15px",
+        alignItems: "baseline",
         background: "#353535",
         color: "white",
+        display: "flex",
+        justifyContent: "space-between",
         left: "0",
-        zIndex: "999",
-        lineHeight: "30px",
-        textAlign: "left"
+        padding: "15px",
+        position: "fixed",
+        width: "100%",
+        zIndex: "999"
       },
+      contentStyle: {},
       buttonStyle: {
-        position: "absolute",
-        right: "50px",
-        border: "0",
         background: "#ffd42d",
-        boxShadow: "none",
+        border: "0",
         borderRadius: "0px",
-        padding: "5px",
-        color: "black"
+        boxShadow: "none",
+        color: "black",
+        flex: "0 0 auto",
+        marginLeft: "15px",
+        padding: "5px 10px"
       }
     };
   }
 
-  componentWillMount(){
+  componentWillMount() {
     const { cookieName } = this.props;
 
-    if (Cookies.get(cookieName) != undefined ) {
+    if (Cookies.get(cookieName) != undefined) {
       this.setState({ visible: false });
     }
   }
@@ -57,7 +59,6 @@ class CookieConsent extends Component {
   }
 
   render() {
-
     // If the bar shouldn't be visible don't render anything.
     if (!this.state.visible) {
       return null;
@@ -67,24 +68,31 @@ class CookieConsent extends Component {
       location,
       style,
       buttonStyle,
+      contentStyle,
       disableStyles,
       onAccept,
       buttonText
     } = this.props;
 
-    let myStyle = {},
-      myButtonStyle = {};
+    let myStyle = {};
+    let myButtonStyle = {};
+    let myTextStyle = {};
 
     if (disableStyles) {
       // if styles are disabled use the provided styles (or non)
       myStyle = Object.assign({}, style);
       myButtonStyle = Object.assign({}, buttonStyle);
+      myTextStyle = Object.assign({}, contentStyle);
     } else {
       // if styles aren't disabled merge them with the styles that are provided (or use default styles)
       myStyle = Object.assign({}, { ...this.state.style, ...style });
       myButtonStyle = Object.assign(
         {},
         { ...this.state.buttonStyle, ...buttonStyle }
+      );
+      myTextStyle = Object.assign(
+        {},
+        { ...this.state.contentStyle, ...contentStyle }
       );
     }
 
@@ -101,7 +109,7 @@ class CookieConsent extends Component {
 
     return (
       <div className="cookieConsent" style={myStyle}>
-        {this.props.children}
+        <div style={myTextStyle}>{this.props.children}</div>
         <button
           style={myButtonStyle}
           onClick={() => {
@@ -120,10 +128,15 @@ CookieConsent.propTypes = {
   location: PropTypes.oneOf(["top", "bottom"]),
   style: PropTypes.object,
   buttonStyle: PropTypes.object,
+  contentStyle: PropTypes.object,
   children: PropTypes.any, // eslint-disable-line react/forbid-prop-types
   disableStyles: PropTypes.bool,
   onAccept: PropTypes.func,
-  buttonText: PropTypes.oneOfType([PropTypes.string,PropTypes.func,PropTypes.element]),
+  buttonText: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.func,
+    PropTypes.element
+  ]),
   cookieName: PropTypes.string
 };
 CookieConsent.defaultProps = {
@@ -135,4 +148,4 @@ CookieConsent.defaultProps = {
 };
 
 export default CookieConsent;
-export {Cookies};
+export { Cookies };


### PR DESCRIPTION
Issue: When the text in the bar becomes too long the button may overlap it. 
Improvement: Style the bar with flexbox. 
Solution: For this I had to make the bar a `display: flex` and introduce a `div` around the content, so that children can be aligned. The button can now be aligned to the content according to `justify-content`.

**NOTE**: the links in the README to the default stylings only become valid after the PR.