### PR TITLE
Default visibility should be false

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "printWidth": 100,
+  "semi": true,
+  "single-quote": false
+}

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ class CookieConsent extends Component {
     this.accept.bind(this);
 
     this.state = {
-      visible: true,
+      visible: false,
       style: {
         alignItems: "baseline",
         background: "#353535",
@@ -46,11 +46,9 @@ class CookieConsent extends Component {
   componentWillMount() {
     const { cookieName, debug } = this.props;
 
-    // debug not desired and cookieName not undefined
-    if (!debug &&
-      Cookies.get(cookieName) !== undefined
-    ) {
-      this.setState({ visible: false });
+    // if debug desired or cookieName undefined
+    if (debug || Cookies.get(cookieName) === undefined) {
+      this.setState({ visible: true });
     }
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -90,14 +90,8 @@ class CookieConsent extends Component {
     } else {
       // if styles aren't disabled merge them with the styles that are provided (or use default styles)
       myStyle = Object.assign({}, { ...this.state.style, ...style });
-      myButtonStyle = Object.assign(
-        {},
-        { ...this.state.buttonStyle, ...buttonStyle }
-      );
-      myContentStyle = Object.assign(
-        {},
-        { ...this.state.contentStyle, ...contentStyle }
-      );
+      myButtonStyle = Object.assign({}, { ...this.state.buttonStyle, ...buttonStyle });
+      myContentStyle = Object.assign({}, { ...this.state.contentStyle, ...contentStyle });
     }
 
     // syntactic sugar to enable user to easily select top / bottom
@@ -136,11 +130,7 @@ CookieConsent.propTypes = {
   children: PropTypes.any, // eslint-disable-line react/forbid-prop-types
   disableStyles: PropTypes.bool,
   onAccept: PropTypes.func,
-  buttonText: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-    PropTypes.element
-  ]),
+  buttonText: PropTypes.oneOfType([PropTypes.string, PropTypes.func, PropTypes.element]),
   cookieName: PropTypes.string,
   debug: PropTypes.bool
 };


### PR DESCRIPTION
The cookie bar should only be shown one time. So the default should be `visibility: false`. Only if a cookie does not yet exist or `debug={true}` visibility is set to true. 

With the previous logic, whenever a website was refreshed, there was a little flash of the bar, which then disappeared. This resulted from reading the cookie. With the new logic, this flash is gone, because no state change takes place and the component is not re-rendered.

I also added .prettierrc which led to some formatting changes.