### PR TITLE
Prevent flashing of component

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -43,12 +43,14 @@ class CookieConsent extends Component {
     };
   }
 
-  componentWillMount() {
+  componentDidMount() {
     const { cookieName, debug } = this.props;
 
-    // if debug desired or cookieName undefined
-    if (debug || Cookies.get(cookieName) === undefined) {
-      this.setState({ visible: true });
+    // if cookie undefined or debug
+    if (Cookies.get(cookieName) === undefined || debug) {
+      this.setState(() => {
+        visible: true;
+      });
     }
   }
 
@@ -59,7 +61,9 @@ class CookieConsent extends Component {
     const { cookieName } = this.props;
 
     Cookies.set(cookieName, true);
-    this.setState({ visible: false });
+    this.setState(() => {
+      visible: false;
+    });
   }
 
   render() {

--- a/src/index.js
+++ b/src/index.js
@@ -48,9 +48,7 @@ class CookieConsent extends Component {
 
     // if cookie undefined or debug
     if (Cookies.get(cookieName) === undefined || debug) {
-      this.setState(() => {
-        visible: true;
-      });
+      this.setState({ visible: true });
     }
   }
 
@@ -61,9 +59,7 @@ class CookieConsent extends Component {
     const { cookieName } = this.props;
 
     Cookies.set(cookieName, true);
-    this.setState(() => {
-      visible: false;
-    });
+    this.setState({ visible: false });
   }
 
   render() {


### PR DESCRIPTION
The component was still flashing, so I read up:

1. setState() is asnychronous. 
[https://reactjs.org/docs/react-component.html#setstate](https://reactjs.org/docs/react-component.html#setstate)

2. do not use componentWillMount():
[https://reactjs.org/docs/react-component.html#unsafe_componentwillmount](https://reactjs.org/docs/react-component.html#unsafe_componentwillmount)
    >UNSAFE_componentWillMount() is invoked just before mounting occurs. It is called before render(), therefore calling setState() synchronously in this method will not trigger an extra rendering. Generally, we recommend using the constructor() instead for initializing state.

    >Avoid introducing any side-effects or subscriptions in this method. For those use cases, use componentDidMount() instead.

3. the correct place is componentDidMount():
[https://reactjs.org/docs/react-component.html#componentdidmount](https://reactjs.org/docs/react-component.html#componentdidmount):

    >componentDidMount() is invoked immediately after a component is mounted. Initialization that requires DOM nodes should go here. If you need to load data from a remote endpoint, this is a good place to instantiate the network request.
    > [...]
    >Calling setState() in this method will trigger an extra rendering, but it will happen before the browser updates the screen. This guarantees that even though the render() will be called twice in this case, the user won’t see the intermediate state.

    I suppose, loading a cookie is remote.

