### PR TITLE
Persistent cookies are set with expiration dates by Law Every 12 months.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -58,7 +58,7 @@ class CookieConsent extends Component {
   accept() {
     const { cookieName } = this.props;
 
-    Cookies.set(cookieName, true);
+    Cookies.set(cookieName, true, { expires: 365 });
     this.setState({ visible: false });
   }
 


### PR DESCRIPTION
Persistent cookies

- It is called a permanent cookie, or a stored cookie, a cookie that is stored on a users hard drive until it expires (persistent cookies are set with expiration dates) or until the user deletes the cookie. 

- Every 12 months, upon the user’s first visit to the site, the consent pops up again asking for a renewal of the consent.