### PR TITLE
Add TypeScript Definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
   "version": "1.9.0",
   "description": "A small, simple and customizable cookie consent bar for use in React applications.",
   "main": "build/index.js",
+  "types": "build/index.d.ts",
   "dependencies": {
+    "copy-webpack-plugin": "^4.6.0",
     "js-cookie": "^2.2.0",
     "react": "^16.4.0"
   },

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,29 +1,29 @@
 import * as React from 'react';
 import Cookies from "js-cookie";
 
-export interface ICookieConcentProps {
-    location?: "top" | "bottom" | "none",
-    style?: object,
-    buttonStyle?: object,
-    contentStyle?: object,
-    children?: React.ReactNode,
-    disableStyles?: boolean,
-    hideOnAccept?: boolean,
-    onAccept?: Function,
-    buttonText?: Function | React.ReactNode,
-    cookieName?: string,
-    cookieValue?: string | boolean | number,
-    debug?: boolean,
-    expires?: number,
-    containerClasses?: string,
-    contentClasses?: string,
-    buttonClasses?: string,
-    buttonId?: string,
-    acceptOnScroll?: boolean,
-    acceptOnScrollPercentage?: number,
-    extraCookieOptions?: object
+export interface CookieConsentProps {
+  location?: "top" | "bottom" | "none",
+  style?: object,
+  buttonStyle?: object,
+  contentStyle?: object,
+  children?: React.ReactNode,
+  disableStyles?: boolean,
+  hideOnAccept?: boolean,
+  onAccept?: Function,
+  buttonText?: Function | React.ReactNode,
+  cookieName?: string,
+  cookieValue?: string | boolean | number,
+  debug?: boolean,
+  expires?: number,
+  containerClasses?: string,
+  contentClasses?: string,
+  buttonClasses?: string,
+  buttonId?: string,
+  acceptOnScroll?: boolean,
+  acceptOnScrollPercentage?: number,
+  extraCookieOptions?: object
 }
 
-export default class CookieConcent extends React.Component<ICookieConcentProps, {}> {}
+export default class CookieConsent extends React.Component<CookieConsentProps, {}> {}
 
 export { Cookies };

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import Cookies from "js-cookie";
+
+export interface ICookieConcentProps {
+    location?: "top" | "bottom" | "none",
+    style?: object,
+    buttonStyle?: object,
+    contentStyle?: object,
+    children?: React.ReactNode,
+    disableStyles?: boolean,
+    hideOnAccept?: boolean,
+    onAccept?: Function,
+    buttonText?: Function | React.ReactNode,
+    cookieName?: string,
+    cookieValue?: string | boolean | number,
+    debug?: boolean,
+    expires?: number,
+    containerClasses?: string,
+    contentClasses?: string,
+    buttonClasses?: string,
+    buttonId?: string,
+    acceptOnScroll?: boolean,
+    acceptOnScrollPercentage?: number,
+    extraCookieOptions?: object
+}
+
+export default class CookieConcent extends React.Component<ICookieConcentProps, {}> {}
+
+export { Cookies };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,6 @@
 var path = require('path');
+var CopyWebpackPlugin = require('copy-webpack-plugin');
+
 module.exports = {
   entry: './src/index.js',
   output: {
@@ -23,5 +25,8 @@ module.exports = {
   },
   externals: {
     'react': 'commonjs react' // this line is just to use the React dependency of our parent-testing-project instead of using our own React.
-  }
+  },
+  plugins: [
+    new CopyWebpackPlugin([{ from: 'src/index.d.ts', to: 'index.d.ts' }])
+  ]
 };


### PR DESCRIPTION
Add a TypeScript Definition, and "build" it with webpack to the build folder.

This will add correct typings, if you use TypeScript with React.

#27