### PR TITLE
Fix misplaced dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-stage-1": "^6.24.1",
     "copy-webpack-plugin": "^4.6.0",
+    "react": "^16.4.0",
     "webpack": "^2.6.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "dependencies": {
-    "copy-webpack-plugin": "^4.6.0",
-    "js-cookie": "^2.2.0",
+    "js-cookie": "^2.2.0"
+  },
+  "peerDependencies": {
     "react": "^16.4.0"
   },
   "scripts": {
@@ -45,6 +46,7 @@
     "babel-preset-env": "^1.5.1",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-stage-1": "^6.24.1",
+    "copy-webpack-plugin": "^4.6.0",
     "webpack": "^2.6.1"
   }
 }


### PR DESCRIPTION
Move `react` to `peerDependencies` and  `copy-webpack-plugin` to `devDependencies`

Closes #30