### PR TITLE
Adjust the typing and the prop-type definitions related to the ButtonComponent

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -32,7 +32,7 @@ export interface CookieConsentProps {
   disableButtonStyles?: boolean;
   enableDeclineButton?: boolean;
   flipButtons?: boolean;
-  ButtonComponent?: Function | React.ReactElement;
+  ButtonComponent?: React.ElementType;
 }
 
 export default class CookieConsent extends React.Component<CookieConsentProps, {}> {}

--- a/src/index.js
+++ b/src/index.js
@@ -301,7 +301,7 @@ CookieConsent.propTypes = {
   disableButtonStyles: PropTypes.bool,
   enableDeclineButton: PropTypes.bool,
   flipButtons: PropTypes.bool,
-  ButtonComponent: PropTypes.oneOfType([PropTypes.func, PropTypes.element])
+  ButtonComponent: PropTypes.elementType
 };
 
 CookieConsent.defaultProps = {


### PR DESCRIPTION
Adjusting the Typescript typing and the prop-types definition to allow the custom button component to be a styled-components instance.

The new definitions should be good for all the possible component cases - functional, class, or styled like in my use case.

Current error:
<img width="678" alt="Screenshot 2020-05-08 at 0 23 14" src="https://user-images.githubusercontent.com/24395456/81347128-2fe8d800-90c4-11ea-9173-a99a728c8182.png">

Useful links:
https://github.com/styled-components/styled-components/issues/2271