### PR TITLE
Set cookie value before handling side-effects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### changed
+
+- Set cookie value before handling side-effects.
+
 ## [5.1.0]
 
 A new feature! This time it's an "overlay" on the entire website to block access whilst the cookiebar is displayed.

--- a/src/index.js
+++ b/src/index.js
@@ -352,8 +352,7 @@ CookieConsent.propTypes = {
   disableStyles: PropTypes.bool,
   hideOnAccept: PropTypes.bool,
   hideOnDecline: PropTypes.bool,
-  
-: PropTypes.func,
+  onAccept: PropTypes.func,
   onDecline: PropTypes.func,
   buttonText: PropTypes.oneOfType([PropTypes.string, PropTypes.func, PropTypes.element]),
   declineButtonText: PropTypes.oneOfType([PropTypes.string, PropTypes.func, PropTypes.element]),

--- a/src/index.js
+++ b/src/index.js
@@ -117,14 +117,14 @@ class CookieConsent extends Component {
    */
   accept({ acceptedByScrolling = false }) {
     const { cookieName, cookieValue, hideOnAccept, onAccept } = this.props;
+    
+    this.setCookie(cookieName, cookieValue);
 
     // fire onAccept
     onAccept({ acceptedByScrolling });
 
     // remove listener if set
     window.removeEventListener("scroll", this.handleScroll);
-
-    this.setCookie(cookieName, cookieValue);
 
     if (hideOnAccept) {
       this.setState({ visible: false });
@@ -144,16 +144,16 @@ class CookieConsent extends Component {
       extraCookieOptions,
       setDeclineCookie,
     } = this.props;
-
+    
+    if (setDeclineCookie) {
+      this.setCookie(cookieName, declineCookieValue);
+    }
+    
     // fire onDecline
     onDecline();
 
     // remove listener if set
     window.removeEventListener("scroll", this.handleScroll);
-
-    if (setDeclineCookie) {
-      this.setCookie(cookieName, declineCookieValue);
-    }
 
     if (hideOnDecline) {
       this.setState({ visible: false });
@@ -352,7 +352,8 @@ CookieConsent.propTypes = {
   disableStyles: PropTypes.bool,
   hideOnAccept: PropTypes.bool,
   hideOnDecline: PropTypes.bool,
-  onAccept: PropTypes.func,
+  
+: PropTypes.func,
   onDecline: PropTypes.func,
   buttonText: PropTypes.oneOfType([PropTypes.string, PropTypes.func, PropTypes.element]),
   declineButtonText: PropTypes.oneOfType([PropTypes.string, PropTypes.func, PropTypes.element]),


### PR DESCRIPTION
### Changed

- Set cookie value before handling side-effects

---

When using this package in combination with https://github.com/andreas-straub/gatsby-plugin-gdpr-tracking#google-analytics you can call `window.trackGoogleAnalytics()` to start tracking after giving consent. The problem is that the cookie value is only updated after the `onAccept` prop is called, so calling the mentioned method would not have any effect.