### PR TITLE
Added support for IE11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [[6.2.3](https://github.com/Mastermindzh/react-cookie-consent/releases/tag/6.2.3)]
+
+- Added support for IE11, the webpack generated runtime-code should not use arrow functions
+
 ## [[6.2.2](https://github.com/Mastermindzh/react-cookie-consent/releases/tag/6.2.2)]
 
 - Fixed the return type of getCookieConsentValue in the dts file.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,6 +7,9 @@ module.exports = {
     path: path.resolve(__dirname, "build"),
     filename: "index.js",
     libraryTarget: "commonjs2", // THIS IS THE MOST IMPORTANT LINE! :mindblow: I wasted more than 2 days until realize this was the line most important in all this guide.
+    environment: {
+      arrowFunction: false, // the generated runtime-code should not use arrow functions
+    },
   },
   module: {
     rules: [


### PR DESCRIPTION
I must admit that I can't remember when was the last time I had such a hard time fixing an issue 😅 The bundled code is fine, it just doesn't work on IE11 giving us a `Syntax error` in the console. 

I noticed that you are using `@babel/preset-env` and therefore the arrow functions transform plugin is included as it also transpiled your code. The issue was that the bundled code was always exporting `module.exports=(()=>...` so after a while I finally managed to find out that, in the newer version of webpack (5) you should specify `arrowFunction: false` in the `output.environment` if you don't want them to use arrow functions. So, after adding that the bundled code starts now with `module.exports=function(){...`

https://webpack.js.org/configuration/output/#outputenvironment

Let me please know if you will need anything else from my side :)