### PR TITLE
Switch Library Type from CommonJs2 => UMD

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,10 @@ module.exports = {
   output: {
     path: path.resolve(__dirname, "build"),
     filename: "index.js",
-    libraryTarget: "commonjs2", // THIS IS THE MOST IMPORTANT LINE! :mindblow: I wasted more than 2 days until realize this was the line most important in all this guide.
+    library: {
+      name: "ReactCookieConsent",
+      type: "umd",
+    },
     environment: {
       arrowFunction: false, // the generated runtime-code should not use arrow functions
     },
@@ -16,7 +19,7 @@ module.exports = {
       {
         test: /\.js$/,
         include: path.resolve(__dirname, "src"),
-        exclude: /(node_modules|bower_components|build)/,
+        exclude: /(node_modules|build)/,
         use: {
           loader: "babel-loader",
           options: {


### PR DESCRIPTION
I was switching a personal project from create-react-app => vite and noticed a production react error, the same as what was happening in this issue:  https://github.com/Mastermindzh/react-cookie-consent/issues/110

Per The suggestion of @jclohmann, I edited the webpack config to switch from commonjs to umd.  This worked perfectly to fix the issue.  It also looks like this resolves a webpack deprecation (`output.libraryTarget`) is deprecated in favor of `output.library`:  https://webpack.js.org/configuration/output/#outputlibrarytarget

I believe this _should_ be safe, and preferred over commonjs.  Per https://github.com/umdjs/umd:

> These are modules which are capable of working everywhere, be it in the client, on the server or elsewhere.

Thanks for this library!  
