### PR TITLE
Fix the TypeScript definition of some properties

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -42,8 +42,8 @@ export interface CookieConsentProps {
   ariaDeclineLabel?: string;
   acceptOnScroll?: boolean;
   acceptOnScrollPercentage?: number;
-  customContentAttributes: object;
-  customContainerAttributes: object;
+  customContentAttributes?: object;
+  customContainerAttributes?: object;
 }
 
 export default class CookieConsent extends React.Component<CookieConsentProps, {}> {}


### PR DESCRIPTION
`customContentAttributes` and `customContainerAttributes` shouldn't be mandatory as they have a default value, according to the `README.md` and the `index.js` files.

Closes #141 