### PR TITLE
added customButtonProps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [next]
+
+- added `customButtonProps` that allows to use custom props with the button component. Specifically useful for library buttons components, for e.g. MUI Button.
+
 ## [[7.2.1]](https://github.com/Mastermindzh/react-cookie-consent/releases/tag/7.2.1)
 
 - hideOnDecline added to typescript files

--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ That option would be interesting if you want to allow user to change their conse
 | customContainerAttributes |                   object                    | `{}`                                 | Allows you to set custom (data) attributes on the container div                                                                         |
 | onOverlayClick            |                  function                   | `() => {}`                           | allows you to react to a click on the overlay                                                                                           |
 | acceptOnOverlayClick      |                   boolean                   | false                                | Determines whether the cookies should be accepted after clicking on the overlay                                                         |
+| customButtonProps         |                   object                    | `{}`                                 | Allows you to set custom props on the button component                                                                                  |
 
 ## Debugging it
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -47,6 +47,7 @@ export interface CookieConsentProps {
   acceptOnScrollPercentage?: number;
   customContentAttributes?: object;
   customContainerAttributes?: object;
+  customButtonProps?: object;
 }
 
 export default class CookieConsent extends React.Component<CookieConsentProps, {}> {}

--- a/src/index.js
+++ b/src/index.js
@@ -292,6 +292,7 @@ class CookieConsent extends Component {
       ariaDeclineLabel,
       customContainerAttributes,
       customContentAttributes,
+      customButtonProps,
     } = this.props;
 
     let myStyle = {};
@@ -359,6 +360,7 @@ class CookieConsent extends Component {
     // add accept button
     buttonsToRender.push(
       <ButtonComponent
+        {...customButtonProps}
         key="acceptButton"
         style={myButtonStyle}
         className={buttonClasses}
@@ -452,6 +454,7 @@ CookieConsent.propTypes = {
   acceptOnScrollPercentage: PropTypes.number,
   customContentAttributes: PropTypes.object,
   customContainerAttributes: PropTypes.object,
+  customButtonProps: PropTypes.object,
 };
 
 CookieConsent.defaultProps = {
@@ -493,6 +496,7 @@ CookieConsent.defaultProps = {
   acceptOnScrollPercentage: 25,
   customContentAttributes: {},
   customContainerAttributes: {},
+  customButtonProps: {},
 };
 
 export default CookieConsent;


### PR DESCRIPTION
Added `customButtonProps` that allows to use custom props with the button component. Specifically useful for library buttons components, for e.g. MUI Button.