### PR TITLE
Update index.d.ts

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -65,12 +65,12 @@ export function getCookieConsentValue(name?: string): string;
  * Remove the cookie on browser in order to allow user to change their consent
  * @param {*} name optional name of the cookie
  */
-export function resetCookieConsentValue(name?: string);
+export function resetCookieConsentValue(name?: string): string;
 
 /**
  * Get the legacy cookie name by the regular cookie name
  * @param {string} name of cookie to get
  */
-export function getLegacyCookieName(name: string);
+export function getLegacyCookieName(name: string): string;
 
 export { Cookies };


### PR DESCRIPTION
Fixes 
'resetCookieConsentValue', which lacks return-type annotation, implicitly has an 'any' return type
'getLegacyCookieName', which lacks return-type annotation, implicitly has an 'any' return type.